### PR TITLE
Rename and improve debug command (-> `debug-mode` ?)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ php bin/console pr:mo install fop_console
 * `fop:export`: Exports object models in XML
 * `fop:shop-status` Display shop(s) status(es)
 * `fop:check-container`   Health check of the Service Container, for now list the services we can't use in Symfony commands 
-* `fop:debug` Configure debug mode
+* `fop:debug-mode` Enable or Disable debug mode.
 * `fop:images:generate:categories` Regenerate categories thumbnails
 * `fop:images:generate:manufacturers` Regenerate manufacturers thumbnails
 * `fop:images:generate:products` Regenerate products thumbnails

--- a/config/services.yml
+++ b/config/services.yml
@@ -29,7 +29,7 @@ services:
     tags:
       - { name: console.command }
 
-  fop.console.display_errors.command:
+  fop.console.debug_mode.command:
     class: FOP\Console\Commands\DebugMode
     tags:
       - { name: console.command }

--- a/config/services.yml
+++ b/config/services.yml
@@ -29,8 +29,8 @@ services:
     tags:
       - { name: console.command }
 
-  fop.console.debug_mod.command:
-    class: FOP\Console\Commands\DebugMode
+  fop.console.display_errors.command:
+    class: FOP\Console\Commands\DisplayErrors
     tags:
       - { name: console.command }
 

--- a/config/services.yml
+++ b/config/services.yml
@@ -30,7 +30,7 @@ services:
       - { name: console.command }
 
   fop.console.display_errors.command:
-    class: FOP\Console\Commands\DisplayErrors
+    class: FOP\Console\Commands\DebugMode
     tags:
       - { name: console.command }
 

--- a/src/Commands/DebugMode.php
+++ b/src/Commands/DebugMode.php
@@ -60,7 +60,8 @@ class DebugMode extends Command
 
         switch ($action) {
             case 'status':
-                $io->text('Current debug mode : ' . $isDebugModEnabled ? 'enabled' : 'disabled');
+                $io->text('Current debug mode : ' . ($isDebugModEnabled ? 'enabled' : 'disabled'));
+                return 0;
                 break;
             case 'toggle':
                 $returnCode = $isDebugModEnabled
@@ -80,7 +81,7 @@ class DebugMode extends Command
         }
 
         if ($returnCode === DebugAdapter::DEBUG_MODE_SUCCEEDED) {
-            $io->success('Debug mode ' . ($debugMode->isDebugModeEnabled() ? 'enabled' : 'disabled') . '.');
+            $io->success('Debug mode changed : ' . ($debugMode->isDebugModeEnabled() ? 'enabled' : 'disabled') . '.');
 
             return 0;
         }

--- a/src/Commands/DebugMode.php
+++ b/src/Commands/DebugMode.php
@@ -61,6 +61,7 @@ class DebugMode extends Command
         switch ($action) {
             case 'status':
                 $io->text('Current debug mode : ' . ($isDebugModEnabled ? 'enabled' : 'disabled'));
+
                 return 0;
                 break;
             case 'toggle':
@@ -86,7 +87,7 @@ class DebugMode extends Command
             return 0;
         }
 
-        $io->error('An error occured while updating debug mode. '.DebugAdapter::class.' error code '.$returnCode.' .');
+        $io->error('An error occured while updating debug mode. ' . DebugAdapter::class . ' error code ' . $returnCode . ' .');
 
         return 1;
     }

--- a/src/Commands/DebugMode.php
+++ b/src/Commands/DebugMode.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class DisplayErrors extends Command
+class DebugMode extends Command
 {
     /**
      * @var array possible allowed dev mode passed in command
@@ -36,7 +36,7 @@ class DisplayErrors extends Command
     protected function configure()
     {
         $this
-            ->setName('fop:errors')
+            ->setName('fop:debug-mode')
             ->setDescription('Enable or Disable debug mode.')
             ->setHelp('Get or change debug mode. Change _PS_MODE_DEV_ value.')
             ->addArgument(

--- a/src/Commands/DisplayErrors.php
+++ b/src/Commands/DisplayErrors.php
@@ -80,7 +80,7 @@ class DisplayErrors extends Command
         }
 
         if ($returnCode === DebugAdapter::DEBUG_MODE_SUCCEEDED) {
-            $io->success('Debug mode (_PS_MODE_DEV_) ' . $action . 'd with success');
+            $io->success('Debug mode ' . ($debugMode->isDebugModeEnabled() ? 'enabled' : 'disabled') . '.');
 
             return 0;
         }

--- a/src/Commands/DisplayErrors.php
+++ b/src/Commands/DisplayErrors.php
@@ -42,7 +42,7 @@ class DisplayErrors extends Command
             ->addArgument(
                 'action',
                 InputArgument::OPTIONAL,
-                'enable or disable debug mode ( possible values : ' . implode(',', self::ALLOWED_COMMAND) . ') ',
+                'enable or disable debug mode ( possible values : ' . $this->getPossibleActions() . ') ',
                 'status'
             );
     }
@@ -58,7 +58,7 @@ class DisplayErrors extends Command
         $isDebugModEnabled = $debugMode->isDebugModeEnabled();
 
         if (!in_array($action, self::ALLOWED_COMMAND)) {
-            $io->error('Action not allowed');
+            $io->error('Action not allowed.'.PHP_EOL.'Possible actions : '.$this->getPossibleActions());
 
             return 1;
         }
@@ -91,5 +91,10 @@ class DisplayErrors extends Command
         }
 
         return 0;
+    }
+
+    private function getPossibleActions(): string
+    {
+        return implode(',', self::ALLOWED_COMMAND);
     }
 }

--- a/src/Commands/DisplayErrors.php
+++ b/src/Commands/DisplayErrors.php
@@ -60,7 +60,7 @@ class DisplayErrors extends Command
 
         switch ($action) {
             case 'status':
-                $io->text('Current debug mode : ' . ((true === $isDebugModEnabled) ? 'enabled' : 'disabled'));
+                $io->text('Current debug mode : ' . $isDebugModEnabled ? 'enabled' : 'disabled');
                 break;
             case 'toggle':
                 $returnCode = $isDebugModEnabled

--- a/src/Commands/DisplayErrors.php
+++ b/src/Commands/DisplayErrors.php
@@ -37,8 +37,8 @@ class DisplayErrors extends Command
     {
         $this
             ->setName('fop:errors')
-            ->setDescription('Configure and display _PS_MODE_DEV_')
-            ->setHelp('Get or change debug mode.')
+            ->setDescription('Enable or Disable debug mode.')
+            ->setHelp('Get or change debug mode. Change _PS_MODE_DEV_ value.')
             ->addArgument(
                 'action',
                 InputArgument::OPTIONAL,

--- a/src/Commands/DisplayErrors.php
+++ b/src/Commands/DisplayErrors.php
@@ -85,7 +85,7 @@ class DisplayErrors extends Command
             return 0;
         }
 
-        $io->error('An error occured while updating debug mode');
+        $io->error('An error occured while updating debug mode. '.DebugAdapter::class.' error code '.$returnCode.' .');
 
         return 1;
     }

--- a/src/Commands/DisplayErrors.php
+++ b/src/Commands/DisplayErrors.php
@@ -23,7 +23,7 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
-class DebugMode extends Command
+class DisplayErrors extends Command
 {
     /**
      * @var array possible allowed dev mode passed in command
@@ -36,9 +36,9 @@ class DebugMode extends Command
     protected function configure()
     {
         $this
-            ->setName('fop:debug')
-            ->setDescription('Configure debug mode')
-            ->setHelp('This command allows you to get or change debug mode')
+            ->setName('fop:errors')
+            ->setDescription('Configure and display _PS_MODE_DEV_')
+            ->setHelp('Get or change debug mode.')
             ->addArgument(
                 'action',
                 InputArgument::OPTIONAL,

--- a/src/Commands/DisplayErrors.php
+++ b/src/Commands/DisplayErrors.php
@@ -63,8 +63,10 @@ class DisplayErrors extends Command
                 $io->text('Current debug mode : ' . ((true === $isDebugModEnabled) ? 'enabled' : 'disabled'));
                 break;
             case 'toggle':
-                $action = (true === $isDebugModEnabled) ? 'disable' : 'enable';
-                // no break
+                $returnCode = $isDebugModEnabled
+                    ? $debugMode->disable()
+                    : $debugMode->enable();
+                break;
             case 'enable':
                 $returnCode = $debugMode->enable();
                 break;


### PR DESCRIPTION
- Issue https://github.com/friends-of-presta/fop_console/issues/47 probably deserve `fop:debug` as name.
- Furthermore, the current `fop:debug` command performs action (change debug mode) which is not what symfony `debug:xxx` commands do. They only display information.

`fop:errors` is probably better. Not very clear but concise. Alternatives may be very long/verbose, unless you have a better suggestion, don't you ?

I also refactored the code, nothing important, but it looks better to me. (may be subjective, (or not)).