### PR TITLE
feat(theme-reset): Reset current theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ php bin/console pr:mo install fop_console
 * `fop:maintenance` get status or change maintenance mode, list or add maintenance ip address
 * `fop:generate:htaccess` Generate the .htaccess file
 * `fop:generate:robots`   Generate the robots.txt file
-* `fop:theme-reseet` Reset current (or selected) theme
+* `fop:theme-reset` Reset current (or selected) theme
 
 ## Create your owns Commands
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ php bin/console pr:mo install fop_console
 * `fop:maintenance` get status or change maintenance mode, list or add maintenance ip address
 * `fop:generate:htaccess` Generate the .htaccess file
 * `fop:generate:robots`   Generate the robots.txt file
+* `fop:theme-reseet` Reset current (or selected) theme
 
 ## Create your owns Commands
 

--- a/config/services.yml
+++ b/config/services.yml
@@ -78,3 +78,8 @@ services:
     class: FOP\Console\Commands\Images\GenerateStores
     tags:
       - { name: console.command }
+
+  fop.console.theme-reset.command:
+    class: FOP\Console\Commands\ThemeResetLayout
+    tags:
+      - { name: console.command }

--- a/src/Commands/ThemeResetLayout.php
+++ b/src/Commands/ThemeResetLayout.php
@@ -52,7 +52,7 @@ final class ThemeResetLayout extends Command
                 ->render();
 
             return self::COMMAND_FAILURE;
-        } else if (count($shops) > 1 && $shopId = $input->getOption(self::ID_SHOP_ARGUMENT)) {
+        } elseif (count($shops) > 1 && $shopId = $input->getOption(self::ID_SHOP_ARGUMENT)) {
             if ($shop = $this->findShopById($shopService->getContextShopId()) === false) {
                 $io->error('An error occurred while selecting shop');
 

--- a/src/Commands/ThemeResetLayout.php
+++ b/src/Commands/ThemeResetLayout.php
@@ -39,7 +39,7 @@ final class ThemeResetLayout extends Command
         $shopService = $container->get('prestashop.adapter.shop.context');
         $shops = $shopService->getShops();
 
-        // Have more than 1 shop without previously select a shop in input option
+        // Have more than 1 shop without previously selected an id_shop in input option
         if (count($shops) > 1 && $input->getOption(self::ID_SHOP_ARGUMENT) === null) {
             $io->error('Your Prestashop installation seems to be a multistore, please define the --' . self::ID_SHOP_ARGUMENT . ' argument');
 

--- a/src/Commands/ThemeResetLayout.php
+++ b/src/Commands/ThemeResetLayout.php
@@ -62,6 +62,6 @@ final class ThemeResetLayout extends Command
             return 1;
         }
 
-        $io->success(sprintf('Theme "%s" resetted with success.', $theme));
+        $io->success(sprintf('Theme "%s" has been successfully reset.', $theme));
     }
 }

--- a/src/Commands/ThemeResetLayout.php
+++ b/src/Commands/ThemeResetLayout.php
@@ -46,6 +46,7 @@ final class ThemeResetLayout extends Command
                 $io->title('resetting current theme : ' . $theme);
             } else {
                 $io->error('An error occurred while selecting current theme');
+
                 return 1;
             }
         }
@@ -55,9 +56,9 @@ final class ThemeResetLayout extends Command
         try {
             $themeManager->enable($theme, 1);
             $themeManager->disable($theme);
-
         } catch (\Exception $e) {
             $io->error(sprintf('The selected theme "%s" is invalid', $theme));
+
             return 1;
         }
 

--- a/src/Commands/ThemeResetLayout.php
+++ b/src/Commands/ThemeResetLayout.php
@@ -3,13 +3,18 @@
 namespace FOP\Console\Commands;
 
 use FOP\Console\Command;
+use Symfony\Component\Console\Helper\Table;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 
 final class ThemeResetLayout extends Command
 {
+    const ID_SHOP_ARGUMENT = 'id_shop';
+    const COMMAND_FAILURE = 1;
+
     /**
      * {@inheritdoc}
      */
@@ -19,7 +24,8 @@ final class ThemeResetLayout extends Command
             ->setName('fop:theme-reset')
             ->setDescription('Reset current theme layout')
             ->setHelp('Disable & re-enable theme configuration')
-            ->addArgument('theme', InputArgument::OPTIONAL, 'Theme on which the action will be executed');
+            ->addArgument('theme', InputArgument::OPTIONAL, 'Theme on which the action will be executed')
+            ->addOption(self::ID_SHOP_ARGUMENT, null, InputOption::VALUE_OPTIONAL, 'Shop on which the action will be executed');
     }
 
     /**
@@ -30,25 +36,35 @@ final class ThemeResetLayout extends Command
         $io = new SymfonyStyle($input, $output);
         $theme = $input->getArgument('theme');
         $container = $this->getContainer();
+        $shopService = $container->get('prestashop.adapter.shop.context');
+        $shops = $shopService->getShops();
 
-        if (!$theme) {
-            $io->text('(?) No theme selected, trying to select current theme...');
-            $shopService = $container->get('prestashop.adapter.shop.context');
-            $shops = $shopService->getShops();
+        // Have more than 1 shop without previously select a shop in input option
+        if (count($shops) > 1 && $input->getOption(self::ID_SHOP_ARGUMENT) === null) {
+            $io->error('Your Prestashop installation seems to be a multistore, please define the --' . self::ID_SHOP_ARGUMENT . ' argument');
 
-            // Retrieve current shop
-            $shopId = $shopService->getContextShopId();
+            $table = new Table($output);
+            $table
+                ->setHeaders(['id_shop', 'Shop name'])
+                ->setRows(array_map(function ($shop) {
+                    return [$shop['id_shop'], $shop['name']];
+                }, $shops))
+                ->render();
 
-            if (isset($shops[$shopId]) && is_array($shops[$shopId])) {
-                $shop = $shops[$shopId];
+            return self::COMMAND_FAILURE;
+        } else if (count($shops) > 1 && $shopId = $input->getOption(self::ID_SHOP_ARGUMENT)) {
+            if ($shop = $this->findShopById($shopService->getContextShopId()) === false) {
+                $io->error('An error occurred while selecting shop');
 
-                $theme = $shop['theme_name'];
-                $io->title('resetting current theme : ' . $theme);
-            } else {
-                $io->error('An error occurred while selecting current theme');
-
-                return 1;
+                return self::COMMAND_FAILURE;
             }
+        } else {
+            $shop = $this->findShopById(1);
+        }
+
+        // If no theme defined in argument, retrieve the current active one
+        if (null === $theme) {
+            $theme = $shop['theme_name'];
         }
 
         $themeManager = $this->getContainer()->get('prestashop.core.addon.theme.theme_manager');
@@ -59,9 +75,24 @@ final class ThemeResetLayout extends Command
         } catch (\Exception $e) {
             $io->error(sprintf('The selected theme "%s" is invalid', $theme));
 
-            return 1;
+            return self::COMMAND_FAILURE;
         }
 
         $io->success(sprintf('Theme "%s" has been successfully reset.', $theme));
+    }
+
+    private function findShopById(int $shopId)
+    {
+        $container = $this->getContainer();
+        $shopService = $container->get('prestashop.adapter.shop.context');
+        $shops = $shopService->getShops();
+
+        foreach ($shops as $shop) {
+            if ($shop['id_shop'] == $shopId) {
+                return $shop;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Commands/ThemeResetLayout.php
+++ b/src/Commands/ThemeResetLayout.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace FOP\Console\Commands;
+
+use FOP\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class ThemeResetLayout extends Command
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('fop:theme-reset')
+            ->setDescription('Reset current theme layout')
+            ->setHelp('Disable & re-enable theme configuration')
+            ->addArgument('theme', InputArgument::OPTIONAL, 'Theme on which the action will be executed');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+        $theme = $input->getArgument('theme');
+        $container = $this->getContainer();
+
+        if (!$theme) {
+            $io->text('(?) No theme selected, trying to select current theme...');
+            $shopService = $container->get('prestashop.adapter.shop.context');
+            $shops = $shopService->getShops();
+
+            // Retrieve current shop
+            $shopId = $shopService->getContextShopId();
+
+            if (isset($shops[$shopId]) && is_array($shops[$shopId])) {
+                $shop = $shops[$shopId];
+
+                $theme = $shop['theme_name'];
+                $io->title('resetting current theme : ' . $theme);
+            } else {
+                $io->error('An error occurred while selecting current theme');
+                return 1;
+            }
+        }
+
+        $themeManager = $this->getContainer()->get('prestashop.core.addon.theme.theme_manager');
+
+        try {
+            $themeManager->enable($theme, 1);
+            $themeManager->disable($theme);
+
+        } catch (\Exception $e) {
+            $io->error(sprintf('The selected theme "%s" is invalid', $theme));
+            return 1;
+        }
+
+        $io->success(sprintf('Theme "%s" resetted with success.', $theme));
+    }
+}


### PR DESCRIPTION
Useful during the theme creation phase.
Allows you to reset the theme (position, modules, ...) without going through the administration interface

If no theme name is passed as an argument. The command will automatically use the active theme.