### PR TITLE
Be able to move/add in bulk clients from one group client to another

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ php bin/console pr:mo install fop_console
 * `fop:latest-products`: Displays the latest products
 * `fop:export`: Exports object models in XML
 * `fop:check-container`   Health check of the Service Container, for now list the services we can't use in Symfony commands
+* `fop:customer-groups`: Move or add in bulk clients from one group client to another
 
 ## Create your owns Commands
 

--- a/config/services.yml
+++ b/config/services.yml
@@ -98,3 +98,7 @@ services:
     class: FOP\Console\Commands\ThemeResetLayout
     tags:
       - { name: console.command }
+  fop.console.customers.groups.command:
+    class: FOP\Console\Commands\Customers\CustomersGroups
+    tags:
+      - { name: console.command }

--- a/src/Commands/Customers/CustomersGroups.php
+++ b/src/Commands/Customers/CustomersGroups.php
@@ -19,7 +19,6 @@
 
 namespace FOP\Console\Commands\Customers;
 
-use Configuration;
 use Customer;
 use FOP\Console\Command;
 use Group;
@@ -191,7 +190,7 @@ final class CustomersGroups extends Command
             switch ((int) $actionAfter) {
                 case self::ACTION_JUST_COPY:
                     $customer->addGroups([$GroupTo->id]);
-                    continue;
+                    continue 2;
                     break;
                 case self::ACTION_REMOVE_CUSTOMERS_TO_FROM_GROUP:
                     $customerGroups = array_diff($customerGroups, [$groupFrom->id]); // remove group from
@@ -343,10 +342,15 @@ final class CustomersGroups extends Command
      */
     private function getDefaultPsGroups(): array
     {
+        $config = $this
+            ->getContainer()
+            ->get('prestashop.adapter.legacy.configuration')
+        ;
+
         return [
-            (int) Configuration::get('PS_UNIDENTIFIED_GROUP'),
-            (int) Configuration::get('PS_GUEST_GROUP'),
-            (int) Configuration::get('PS_CUSTOMER_GROUP'),
+            $config->getInt('PS_UNIDENTIFIED_GROUP'),
+            $config->getInt('PS_GUEST_GROUP'),
+            $config->getInt('PS_CUSTOMER_GROUP'),
         ];
     }
 

--- a/src/Commands/Customers/CustomersGroups.php
+++ b/src/Commands/Customers/CustomersGroups.php
@@ -208,7 +208,7 @@ final class CustomersGroups extends Command
             switch ((int) $actionAfter) {
                 case self::ACTION_JUST_COPY:
                     $customer->addGroups([$GroupTo->id]);
-                    continue;
+                    continue 2;
                     break;
                 case self::ACTION_REMOVE_CUSTOMERS_TO_FROM_GROUP:
                     $customerGroups = array_diff($customerGroups, [$groupFrom->id]); // remove group from

--- a/src/Commands/Customers/CustomersGroups.php
+++ b/src/Commands/Customers/CustomersGroups.php
@@ -70,7 +70,7 @@ final class CustomersGroups extends Command
         $optionsGroupTo = $this->getQuestionsOptions('optionsGroupTo');
 
         if (count($optionsGroupFrom) <= 1) {
-            $output->writeln('<error>command aborted</error>');
+            $output->writeln('<error>command aborted : at least 2 groups and 1 customer are required.</error>');
 
             return self::FAILURE;
         }
@@ -214,7 +214,7 @@ final class CustomersGroups extends Command
                 $groupFrom->delete();
             } catch (\Exception $e) {
                 $output->writeln(
-                    '<error> 
+                    '<error>
                         An error has occurred when try to delete group ' . $this->getGroupName($groupFrom->id) . ' : ' . $e->getMessage() .
                     '</error>'
                 );
@@ -312,9 +312,9 @@ final class CustomersGroups extends Command
 
         $questionConfirm = new ConfirmationQuestion(
             '<question>
-                This action will move the customers from group (' . $groupFromName . ') into group (' . $groupToName . ') and 
-                ' . $selectedActionValue . '. 
-                Continue with this action? (Y/N) : 
+                This action will move the customers from group (' . $groupFromName . ') into group (' . $groupToName . ') and
+                ' . $selectedActionValue . '.
+                Continue with this action? (Y/N) :
             </question>',
             false,
             '/^(y|Y)/i'

--- a/src/Commands/Customers/CustomersGroups.php
+++ b/src/Commands/Customers/CustomersGroups.php
@@ -36,7 +36,7 @@ use Validate;
 final class CustomersGroups extends Command
 {
     public const SUCCESS = 0;
-    public const FAILURE = 1;	    
+    public const FAILURE = 1;
     public const INVALID = 2;
     public const ABORTED = 3;
 
@@ -136,7 +136,7 @@ final class CustomersGroups extends Command
                 )
             );
         }
-        
+
         return self::SUCCESS;
     }
 

--- a/src/Commands/Customers/CustomersGroups.php
+++ b/src/Commands/Customers/CustomersGroups.php
@@ -1,0 +1,369 @@
+<?php
+/**
+ * Copyright (c) Since 2020 Friends of Presta
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file docs/licenses/LICENSE.txt.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to infos@friendsofpresta.org so we can send you a copy immediately.
+ *
+ * @author    Friends of Presta <infos@friendsofpresta.org>
+ * @copyright since 2020 Friends of Presta
+ * @license   https://opensource.org/licenses/AFL-3.0  Academic Free License ("AFL") v. 3.0
+ */
+
+namespace FOP\Console\Commands\Customers;
+
+use Configuration;
+use Customer;
+use FOP\Console\Command;
+use Group;
+use Symfony\Component\Console\Helper\ProgressBar;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Question\ChoiceQuestion;
+use Symfony\Component\Console\Question\ConfirmationQuestion;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Validate;
+
+/**
+ * This command display common information the latest products.
+ */
+final class CustomersGroups extends Command
+{
+    public const ACTION_DELETE_FROM_GROUP = 1;
+    public const ACTION_REMOVE_CUSTOMERS_TO_FROM_GROUP = 2;
+    public const ACTION_JUST_COPY = 3;
+    public const ACTION_CANCEL = 4;
+
+    public $groupQuestionsKeyPrefix;
+    public $actionQuestionsKeyPrefix;
+    public $idLang;
+    public $groups = [];
+    public $displaySummaryTab = true;
+
+    /**
+     * @param string|null $name The name of the command; passing null means it must be set in configure()
+     *
+     * @throws LogicException When the command name is empty
+     */
+    public function __construct($name = null)
+    {
+        parent::__construct($name);
+
+        $this->groupQuestionsKeyPrefix = 'category_';
+        $this->actionQuestionsKeyPrefix = 'action_';
+        $this->idLang = (int) Configuration::get('PS_LANG_DEFAULT');
+        $this->groups = Group::getGroups($this->idLang, false);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure()
+    {
+        $this
+            ->setName('fop:customer-groups')
+            ->setDescription('Customer groups')
+            ->setHelp('Customer groups')
+        ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $helper = $this->getHelper('question');
+
+        $optionsGroupFrom = $this->getQuestionsOptions('optionsGroupFrom');
+        $optionsGroupTo = $this->getQuestionsOptions('optionsGroupTo');
+
+        if (count($optionsGroupFrom) <= 1) {
+            $output->writeln('<error>You must have at least two groups associated with at least one customer</error>');
+
+            return;
+        }
+
+        $questionGroupFrom = new ChoiceQuestion(
+            '<question>Please select the group from :</question>',
+            $optionsGroupFrom
+        );
+
+        $questionGroupFrom->setErrorMessage('Group from %s not found.');
+
+        $groupFrom = $helper->ask($input, $output, $questionGroupFrom);
+        $groupFromId = (int) str_replace($this->groupQuestionsKeyPrefix, '', $groupFrom);
+        $groupFromName = $this->getGroupName($groupFromId);
+        $output->writeln('<info>You have just selected: ' . $groupFromName . '</info>');
+
+        // Remove selected group from in group to list.
+        unset($optionsGroupTo[$this->groupQuestionsKeyPrefix . $groupFromId]);
+
+        $questionGroupTo = new ChoiceQuestion(
+            '<question>Please select the group to :</question>',
+            $optionsGroupTo
+        );
+
+        $questionGroupTo->setErrorMessage('Group to %s not found.');
+
+        $groupTo = $helper->ask($input, $output, $questionGroupTo);
+        $groupToId = (int) str_replace($this->groupQuestionsKeyPrefix, '', $groupTo);
+        $groupToName = $this->getGroupName($groupToId);
+        $output->writeln('<info>You have just selected: ' . $groupToName . '</info>');
+
+        $optionsActions = $this->getQuestionsOptions('optionsActions', $groupFromName);
+
+        // Remove delete action when from group as a PS defautl group
+        if (in_array((int) $groupFromId, $this->getDefaultPsGroups())) {
+            unset($optionsActions[$this->actionQuestionsKeyPrefix . self::ACTION_DELETE_FROM_GROUP]);
+        }
+
+        $questionActions = new ChoiceQuestion(
+            '<question>After moving the customers from (' . $groupFromName . ') group to (' . $groupToName . ') group </question>',
+            $optionsActions
+        );
+
+        $questionActions->setErrorMessage('Invalid action %s .');
+
+        $selectedAction = $helper->ask($input, $output, $questionActions);
+        $selectedActionId = (int) str_replace($this->actionQuestionsKeyPrefix, '', $selectedAction);
+        $output->writeln('<info>You have just selected: ' . $optionsActions[$selectedAction] . '</info>');
+
+        if (self::ACTION_CANCEL === (int) $selectedActionId) {
+            $output->writeln('<info>Action canceled</info>');
+
+            return;
+        }
+
+        if (!$this->userConfirmation(
+            $input,
+            $output,
+            $groupFromName,
+            $groupToName,
+            $optionsActions[$selectedAction]
+        )) {
+            $output->writeln('<info>Action abandoned</info>');
+
+            return;
+        }
+
+        $this->groupCustomersTransfer($groupFromId, $groupToId, $selectedActionId, $output);
+
+        if ($this->displaySummaryTab) {
+            // Summary  Tab :
+
+            $io = new SymfonyStyle($input, $output);
+            $io->title('Customers groups');
+
+            $io->table(
+                ['ID', 'Category name', 'Members Nb', 'Reduction (%)'],
+                $this->formatGroupsInformations(
+                    Group::getGroups($this->idLang, false), // refresh groups to avoid old datas.
+                    'table'
+                )
+            );
+        }
+    }
+
+    /**
+     * @param int $idGroupFrom
+     * @param int $IdGroupTo
+     * @param int $actionAfter
+     * @param OutputInterface $output
+     *
+     * @return null
+     */
+    private function groupCustomersTransfer(
+        int $idGroupFrom,
+        int $IdGroupTo,
+        int $actionAfter,
+        OutputInterface $output
+    ): void {
+        $groupFrom = new Group($idGroupFrom);
+        $GroupTo = new Group($IdGroupTo);
+        $hasError = 0;
+
+        if (!Validate::isLoadedObject($groupFrom)
+         || !Validate::isLoadedObject($GroupTo)) {
+            $output->writeln('<error>Invalid groups given </error>');
+
+            return;
+        }
+
+        $groupFromCustomers = $groupFrom->getCustomers();
+
+        $progress = new ProgressBar($output, count($groupFromCustomers));
+        $progress->start();
+
+        foreach ($groupFromCustomers as $k => $v) {
+            $customer = new Customer($v['id_customer']);
+            $customerGroups = $customer->getGroups();
+
+            switch ((int) $actionAfter) {
+                case self::ACTION_JUST_COPY:
+                    $customer->addGroups([$GroupTo->id]);
+                    continue;
+                    break;
+                case self::ACTION_REMOVE_CUSTOMERS_TO_FROM_GROUP:
+                    $customerGroups = array_diff($customerGroups, [$groupFrom->id]); // remove group from
+                    break;
+            }
+
+            array_push($customerGroups, $GroupTo->id); // add group to
+
+            if ((int) $groupFrom->id == (int) $customer->id_default_group) {
+                $customer->id_default_group = (int) $GroupTo->id;
+            }
+
+            try {
+                $customer->updateGroup($customerGroups);
+                $customer->update();
+            } catch (\Exception $e) {
+                $output->writeln(
+                        '<error>
+                            An error has occurred when try to update customer ' . $customer->email . ' to group ' . $this->getGroupName($groupFrom->id) . ' : ' . $e->getMessage() .
+                        '</error>'
+                    );
+                ++$hasError;
+
+                return;
+            }
+
+            $progress->advance();
+        }
+
+        // Delete the form group
+        if (self::ACTION_DELETE_FROM_GROUP == (int) $actionAfter && !$hasError) {
+            try {
+                $groupFrom->delete();
+            } catch (\Exception $e) {
+                $output->writeln(
+                    '<error> 
+                        An error has occurred when try to delete group ' . $this->getGroupName($groupFrom->id) . ' : ' . $e->getMessage() .
+                    '</error>'
+                );
+
+                return;
+            }
+        }
+    }
+
+    /**
+     * @param array $groups groups datas
+     * @param string $type
+     * @param bool $skipEmpty
+     *
+     * @return array
+     */
+    private function formatGroupsInformations(array $groups, $type = 'table', $skipEmpty = false): array
+    {
+        $groupsInformations = [];
+
+        foreach ($groups as $group) {
+            $groupObject = new Group((int) $group['id_group']);
+            $nb = $groupObject->getCustomers(true);
+
+            if ($nb <= 0 && $skipEmpty) {
+                continue;
+            }
+
+            if ($type === 'table') {
+                $groupsInformations[] = [
+                    $groupObject->id,
+                    $group['name'],
+                    $nb,
+                    $groupObject->reduction . ' %',
+                ];
+            } elseif ($type === 'question') {
+                $groupsInformations[$this->groupQuestionsKeyPrefix . $groupObject->id] = $group['name'] . ' (' . $nb . ')';
+            }
+        }
+
+        return $groupsInformations;
+    }
+
+    /**
+     * @param int $type
+     *
+     * @return string
+     */
+    private function getGroupName(int $idGroup): string
+    {
+        return (new Group($idGroup, $this->idLang))->name;
+    }
+
+    /**
+     * @param string $type
+     * @param string $groupFromName
+     *
+     * @return array
+     */
+    private function getQuestionsOptions(string $type, string $groupFromName = null): array
+    {
+        $questionsOptions = [
+            'optionsGroupFrom' => $this->formatGroupsInformations($this->groups, 'question', true),
+            'optionsGroupTo' => $this->formatGroupsInformations($this->groups, 'question', false),
+            'optionsActions' => [
+                $this->actionQuestionsKeyPrefix . self::ACTION_DELETE_FROM_GROUP => 'Delete (' . $groupFromName . ') group',
+                $this->actionQuestionsKeyPrefix . self::ACTION_REMOVE_CUSTOMERS_TO_FROM_GROUP => 'Remove customers in (' . $groupFromName . ') group',
+                $this->actionQuestionsKeyPrefix . self::ACTION_JUST_COPY => 'Just add to new group',
+                $this->actionQuestionsKeyPrefix . self::ACTION_CANCEL => 'Cancel current action',
+            ],
+        ];
+
+        return $questionsOptions[$type] ?? [];
+    }
+
+    /**
+     * user confirmation
+     *
+     * @param InputInterface $input
+     * @param OutputInterface $output
+     * @param string $groupFromName
+     * @param string $groupToName
+     * @param string $selectedActionValue
+     *
+     * @return bool
+     */
+    private function userConfirmation(
+        InputInterface $input,
+        OutputInterface $output,
+        string $groupFromName,
+        string $groupToName,
+        string $selectedActionValue
+    ): bool {
+        $helper = $this->getHelper('question');
+
+        $questionConfirm = new ConfirmationQuestion(
+            '<question>
+                This action will move the customers from group (' . $groupFromName . ') into group (' . $groupToName . ') and 
+                ' . $selectedActionValue . '. 
+                Continue with this action? (Y/N) : 
+            </question>',
+            false,
+            '/^(y|Y)/i'
+        );
+
+        return $helper->ask($input, $output, $questionConfirm);
+    }
+
+    /**
+     * Default Prestashop groups
+     *
+     * @return array
+     */
+    private function getDefaultPsGroups(): array
+    {
+        return [
+            (int) Configuration::get('PS_UNIDENTIFIED_GROUP'),
+            (int) Configuration::get('PS_GUEST_GROUP'),
+            (int) Configuration::get('PS_CUSTOMER_GROUP'),
+        ];
+    }
+}

--- a/src/Commands/Customers/CustomersGroups.php
+++ b/src/Commands/Customers/CustomersGroups.php
@@ -35,6 +35,11 @@ use Validate;
  */
 final class CustomersGroups extends Command
 {
+    public const SUCCESS = 0;
+    public const FAILURE = 1;	    
+    public const INVALID = 2;
+    public const ABORTED = 3;
+
     public const ACTION_DELETE_FROM_GROUP = 1;
     public const ACTION_REMOVE_CUSTOMERS_TO_FROM_GROUP = 2;
     public const ACTION_JUST_COPY = 3;
@@ -67,7 +72,7 @@ final class CustomersGroups extends Command
         if (count($optionsGroupFrom) <= 1) {
             $output->writeln('<error>command aborted</error>');
 
-            return;
+            return self::FAILURE;
         }
 
         // Step 1 : Group From Question
@@ -99,7 +104,7 @@ final class CustomersGroups extends Command
         if (self::ACTION_CANCEL === $selectedActionId) {
             $output->writeln('<info>Action canceled</info>');
 
-            return;
+            return self::ABORTED;
         }
 
         // Step 4 : user confirmation Question
@@ -112,7 +117,7 @@ final class CustomersGroups extends Command
         )) {
             $output->writeln('<info>Action abandoned</info>');
 
-            return;
+            return self::ABORTED;
         }
 
         $this->groupCustomersTransfer($groupFromId, $groupToId, $selectedActionId, $output);
@@ -131,6 +136,8 @@ final class CustomersGroups extends Command
                 )
             );
         }
+        
+        return self::SUCCESS;
     }
 
     /**
@@ -139,16 +146,16 @@ final class CustomersGroups extends Command
      * @param int $actionAfter
      * @param OutputInterface $output
      *
-     * @return null
+     * @return int|null
      *
-     * @throws Exception
+     * @throws \Exception
      */
     private function groupCustomersTransfer(
         int $idGroupFrom,
         int $IdGroupTo,
         int $actionAfter,
         OutputInterface $output
-    ): void {
+    ) {
         $groupFrom = new Group($idGroupFrom);
         $GroupTo = new Group($IdGroupTo);
         $hasError = 0;
@@ -157,7 +164,7 @@ final class CustomersGroups extends Command
          || !Validate::isLoadedObject($GroupTo)) {
             $output->writeln('<error>Invalid groups given </error>');
 
-            return;
+            return self::FAILURE;
         }
 
         $groupFromCustomers = $groupFrom->getCustomers();
@@ -197,7 +204,7 @@ final class CustomersGroups extends Command
                     );
                 ++$hasError;
 
-                return;
+                return self::FAILURE;
             }
         }
 
@@ -212,7 +219,7 @@ final class CustomersGroups extends Command
                     '</error>'
                 );
 
-                return;
+                return self::FAILURE;
             }
         }
     }
@@ -352,7 +359,7 @@ final class CustomersGroups extends Command
     /**
      * Defautl lang id
      *
-     * @return in
+     * @return int
      */
     private function getDefautlLang(): int
     {
@@ -375,7 +382,7 @@ final class CustomersGroups extends Command
      *
      * @return int
      *
-     * @throws UnexpectedValueException
+     * @throws \UnexpectedValueException
      */
     private function generateChoiceQuestion(
         InputInterface $input,


### PR DESCRIPTION
# Feature request

Be able to move/add in bulk clients from one group client to another


# Specs

To be able to transfer customers from a **`Group_A`** group to a **`Group_B`**

> #### ⚠️ have at least two groups and at least one customer associated with one of the groups


#### Select groups
1 - be able to select **`Group_A`** (group from) : _only groups with at least one customer_
2 - be able to select **`Group_B`** (group to) : _The previously selected group must not be in this list._

#### Select action before

Select an action once the clients of group **`Group_A`** have been transferred to group **`Group_B`**

1 - Delete **`Group_A`** group :  _if we choose this option group **`Group_A`** will be deleted after transfer_ 
> This option is not displayed if **`Group_A`** is a Pretashop default group (customer, guest, unidentified) 

2 - Remove customers in **`Group_A`** group : if we choose this option customers will be removed from the **`Group_A`** 

> ⚠️ In both cases (1) and (2), if **`Group_A`** was the customer's default group, **`Group_B`** became its default group.

3 - Just add to new group : _if we choose this option users of group **`Group_A`** will be added to group **`Group_B`**_
4 - Cancel current action : _Command exit :)_

# POC

### 🎥 [Click to see screen record](https://drive.google.com/file/d/1vp3jeEmjcV70xIs5TBmVOSKS7Pbkj4eC/view)

![image](https://user-images.githubusercontent.com/16455155/101421141-fbf0c200-38f3-11eb-8594-da6157cc8e00.png)
