### PR TITLE
fix phpstan errors and warning

### DIFF
--- a/src/Commands/AddHook.php
+++ b/src/Commands/AddHook.php
@@ -69,26 +69,24 @@ final class AddHook extends Command
         $title = $input->getOption('title') ?? $helper->ask($input, $output, new Question('<question>Give me the title</question>'));
         $description = $input->getOption('description') ?? $helper->ask($input, $output, new Question('<question>Give me the description</question>'));
 
-        if (!empty($name) && !empty($title) && !empty($description)) {
-            try {
-                $hook = new \Hook();
-                $hook->name = $name;
-                $hook->title = $title;
-                $hook->description = $description;
-                if ($hook->save()) {
-                    $io->getErrorStyle()->success('Your hook has been add !');
-
-                    return 0;
-                }
-            } catch (\Exception $e) {
-                $io->getErrorStyle()->error($e->getMessage());
-
-                return 1;
+        try {
+            if (empty($name) || empty($title) || empty($description)) {
+                throw new \Exception('You must give me a name, title and description !');
             }
-        } else {
-            $io->getErrorStyle()->error('You must give me a name, title and description !');
+
+            $hook = new \Hook();
+            $hook->name = $name;
+            $hook->title = $title;
+            $hook->description = $description;
+            if (!$hook->save()) {
+                throw new \Exception('Failed to save Hook : ' . $hook->validateFields(false, true));
+            }
+        } catch (\Exception $e) {
+            $io->getErrorStyle()->error($e->getMessage());
 
             return 1;
         }
+
+        return 0;
     }
 }

--- a/src/Commands/Images/GenerateAbstract.php
+++ b/src/Commands/Images/GenerateAbstract.php
@@ -35,7 +35,6 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 abstract class GenerateAbstract extends Command
 {
-
     /** @var string Image type (overrided in subclasses) */
     const IMAGE_TYPE = '';
 

--- a/src/Commands/Images/GenerateAbstract.php
+++ b/src/Commands/Images/GenerateAbstract.php
@@ -35,6 +35,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 
 abstract class GenerateAbstract extends Command
 {
+
+    /** @var string Image type (overrided in subclasses) */
+    const IMAGE_TYPE = '';
+
     /** @var array */
     protected $errors = [];
 

--- a/src/Commands/Images/GenerateCategories.php
+++ b/src/Commands/Images/GenerateCategories.php
@@ -21,6 +21,6 @@ namespace FOP\Console\Commands\Images;
 
 class GenerateCategories extends GenerateAbstract
 {
-    /** @var type string */
+    /** @var string Image type  */
     const IMAGE_TYPE = 'categories';
 }

--- a/src/Commands/Images/GenerateCategories.php
+++ b/src/Commands/Images/GenerateCategories.php
@@ -21,6 +21,6 @@ namespace FOP\Console\Commands\Images;
 
 class GenerateCategories extends GenerateAbstract
 {
-    /** @var string Image type  */
+    /** @var string Image type */
     const IMAGE_TYPE = 'categories';
 }

--- a/src/Commands/Images/GenerateManufacturers.php
+++ b/src/Commands/Images/GenerateManufacturers.php
@@ -21,6 +21,6 @@ namespace FOP\Console\Commands\Images;
 
 class GenerateManufacturers extends GenerateAbstract
 {
-    /** @var string Image type  */
+    /** @var string Image type */
     const IMAGE_TYPE = 'manufacturers';
 }

--- a/src/Commands/Images/GenerateManufacturers.php
+++ b/src/Commands/Images/GenerateManufacturers.php
@@ -21,6 +21,6 @@ namespace FOP\Console\Commands\Images;
 
 class GenerateManufacturers extends GenerateAbstract
 {
-    /** @var type string */
+    /** @var string Image type  */
     const IMAGE_TYPE = 'manufacturers';
 }

--- a/src/Commands/Images/GenerateProducts.php
+++ b/src/Commands/Images/GenerateProducts.php
@@ -21,6 +21,6 @@ namespace FOP\Console\Commands\Images;
 
 class GenerateProducts extends GenerateAbstract
 {
-    /** @var type string */
+    /** @var string Image type  */
     const IMAGE_TYPE = 'products';
 }

--- a/src/Commands/Images/GenerateProducts.php
+++ b/src/Commands/Images/GenerateProducts.php
@@ -21,6 +21,6 @@ namespace FOP\Console\Commands\Images;
 
 class GenerateProducts extends GenerateAbstract
 {
-    /** @var string Image type  */
+    /** @var string Image type */
     const IMAGE_TYPE = 'products';
 }

--- a/src/Commands/Images/GenerateStores.php
+++ b/src/Commands/Images/GenerateStores.php
@@ -21,6 +21,6 @@ namespace FOP\Console\Commands\Images;
 
 class GenerateStores extends GenerateAbstract
 {
-    /** @var type string */
+    /** @var string Image type  */
     const IMAGE_TYPE = 'stores';
 }

--- a/src/Commands/Images/GenerateStores.php
+++ b/src/Commands/Images/GenerateStores.php
@@ -21,6 +21,6 @@ namespace FOP\Console\Commands\Images;
 
 class GenerateStores extends GenerateAbstract
 {
-    /** @var string Image type  */
+    /** @var string Image type */
     const IMAGE_TYPE = 'stores';
 }

--- a/src/Commands/Images/GenerateSuppliers.php
+++ b/src/Commands/Images/GenerateSuppliers.php
@@ -21,6 +21,6 @@ namespace FOP\Console\Commands\Images;
 
 class GenerateSuppliers extends GenerateAbstract
 {
-    /** @var type string */
+    /** @var string Image type  */
     const IMAGE_TYPE = 'suppliers';
 }

--- a/src/Commands/Images/GenerateSuppliers.php
+++ b/src/Commands/Images/GenerateSuppliers.php
@@ -21,6 +21,6 @@ namespace FOP\Console\Commands\Images;
 
 class GenerateSuppliers extends GenerateAbstract
 {
-    /** @var string Image type  */
+    /** @var string Image type */
     const IMAGE_TYPE = 'suppliers';
 }

--- a/src/Controllers/ConsoleController.php
+++ b/src/Controllers/ConsoleController.php
@@ -29,7 +29,6 @@ class ConsoleController extends Controller
     public function __construct()
     {
         parent::__construct();
-        $this->id = 0;
         $this->controller_type = 'console';
     }
 


### PR DESCRIPTION
So we can add phpstan workflow when this errors will be fixed.

Errors are currently :

```
Detected PS version 1.7.5.2
 ------ ---------------------------------------------------------------------- 
  Line   src/Commands/AddHook.php                                              
 ------ ---------------------------------------------------------------------- 
  72     Method FOP\Console\Commands\AddHook::execute() should return int but  
         return statement is missing.                                          
 ------ ---------------------------------------------------------------------- 

 ------ ----------------------------------------------------------- 
  Line   src/Commands/Images/GenerateAbstract.php                   
 ------ ----------------------------------------------------------- 
  60     Access to undefined constant                               
         FOP\Console\Commands\Images\GenerateAbstract::IMAGE_TYPE.  
  61     Access to undefined constant                               
         FOP\Console\Commands\Images\GenerateAbstract::IMAGE_TYPE.  
  89     Access to undefined constant                               
         FOP\Console\Commands\Images\GenerateAbstract::IMAGE_TYPE.  
  101    Access to undefined constant                               
         FOP\Console\Commands\Images\GenerateAbstract::IMAGE_TYPE.  
 ------ ----------------------------------------------------------- 

 ------ ------------------------------------------------- 
  Line   src/Controllers/ConsoleController.php            
 ------ ------------------------------------------------- 
  32     Access to an undefined property                  
         FOP\Console\Controllers\ConsoleController::$id.  
 ------ ------------------------------------------------- 

 [ERROR] Found 6 errors   
```
