### PR TITLE
Command to export / import configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ php bin/console pr:mo install fop_console
 * `fop:latest-products`: Displays the latest products
 * `fop:export`: Exports object models in XML
 * `fop:check-container`   Health check of the Service Container, for now list the services we can't use in Symfony commands
+* `fop:configuration:export` Export configuration values to a json file
+* `fop:configuration:import` Import configuration values from a json file
 
 ## Create your owns Commands
 

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,8 @@
     }
   },
   "require": {
-    "php": "7.2 - 7.3"
+    "php": "^7.1",
+    "ext-json": "*"
   },
   "config": {
     "prepend-autoloader": false

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   },
   "require": {
-    "php": "^7.1"
+    "php": "7.2 - 7.3"
   },
   "config": {
     "prepend-autoloader": false

--- a/config/services.yml
+++ b/config/services.yml
@@ -103,3 +103,8 @@ services:
     class: FOP\Console\Commands\Configuration\Export
     tags:
       - { name: console.command }
+
+  fop.console.configuration.import:
+    class: FOP\Console\Commands\Configuration\Import
+    tags:
+      - { name: console.command }

--- a/config/services.yml
+++ b/config/services.yml
@@ -13,7 +13,7 @@ services:
     class: FOP\Console\Commands\UnhookModule
     tags:
       - { name: console.command }
-  
+
   fop.console.hook_module.command:
     class: FOP\Console\Commands\HookModule
     tags:
@@ -111,6 +111,8 @@ services:
 
   fop.console.configuration.import:
     class: FOP\Console\Commands\Configuration\Import
+    tags:
+      - { name: console.command }
 
   fop.console.customers.groups.command:
     class: FOP\Console\Commands\Customers\CustomersGroups

--- a/config/services.yml
+++ b/config/services.yml
@@ -98,3 +98,8 @@ services:
     class: FOP\Console\Commands\ThemeResetLayout
     tags:
       - { name: console.command }
+
+  fop.console.configuration.export:
+    class: FOP\Console\Commands\Configuration\Export
+    tags:
+      - { name: console.command }

--- a/src/Commands/Configuration/Export.php
+++ b/src/Commands/Configuration/Export.php
@@ -59,9 +59,6 @@ final class Export extends Command
         /** @var \PrestaShop\PrestaShop\Adapter\Configuration $configuration_service */
         $configuration_service = $this->getContainer()->get('prestashop.adapter.legacy.configuration');
 
-        // @todo what to do if configuration key not found ?
-        // for the moment let's emit a simple warning. (throw an error is better ?)
-        // or event create an empty configuration value ?
         $to_export = [];
         foreach ($configuration_keys as $key) {
             // keys to query with a 'like' syntaxe from db

--- a/src/Commands/Configuration/Export.php
+++ b/src/Commands/Configuration/Export.php
@@ -21,12 +21,19 @@ final class Export extends Command
     protected function configure(): void
     {
         $this->setName('fop:configuration:export')
-            ->setDescription('Export configuration values')
+            ->setDescription('Export configuration values (from ps_configuration table).')
             ->setHelp(
                 'Dump configuration(s) to a json file.'
                 . PHP_EOL . 'Exported file can later be used to import values, using configuration:import command.'
                 . PHP_EOL . '<keys> are configuration names, "PS_LANG_DEFAULT" for example, multiple keys can be provided.'
-                . PHP_EOL . '<keys> can also be mysql like values : use "PSGDPR_%" to export all configuration starting with "PSGDPR_" for example.')
+                . PHP_EOL . '<keys> can also be mysql like values : use "PSGDPR_%" to export all configuration starting with "PSGDPR_" for example.'
+                . PHP_EOL . PHP_EOL . 'This command is not multishop, neither multilang.'
+                . PHP_EOL . PHP_EOL . 'Examples :'
+                . PHP_EOL . 'dump one value : <info>./bin/console fop:configuration:export PS_COUNTRY_DEFAULT</info>'
+                . PHP_EOL . 'dump multiples values : <info>./bin/console fop:configuration:export PS_COMBINATION_FEATURE_ACTIVE PS_CUSTOMIZATION_FEATURE_ACTIVE PS_FEATURE_FEATURE_ACTIVE
+</info>'
+                . PHP_EOL . 'dump multiples values using mysql "like" syntax : <info>./bin/console fop:configuration:export --file configuration_blocksocial.json BLOCKSOCIAL_%</info>'
+            )
             ->addOption('file', null, InputOption::VALUE_REQUIRED, 'file to dump to', self::PS_CONFIGURATIONS_FILE)
             ->addOption('force', 'f', InputOption::VALUE_NONE, 'overwrite existing file')
             ->addArgument('keys', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'configuration values to export');

--- a/src/Commands/Configuration/Export.php
+++ b/src/Commands/Configuration/Export.php
@@ -76,18 +76,13 @@ final class Export extends Command
         }
 
         $json_export = json_encode($to_export, JSON_PRETTY_PRINT);
-        if (false === $json_export) { // useless ?
-            if ($io->isVeryVerbose()) {
-                $io->writeln('$to_export:');
-                dump($to_export);
-            }
+        if (false === $json_export) {
             throw new RuntimeException('Failed to json encode configuration');
         }
 
         $fs = new Filesystem();
         $fs->dumpFile($output_file, $json_export);
 
-        // @todo list dumped configurations if verbose mode
         $io->success("configuration(s) dumped to file '{$output_file}'");
 
         return 1;

--- a/src/Commands/Configuration/Export.php
+++ b/src/Commands/Configuration/Export.php
@@ -1,26 +1,69 @@
 <?php
 
+declare(strict_types=1);
+
 namespace FOP\Console\Commands\Configuration;
 
 use FOP\Console\Command;
+use RuntimeException;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Filesystem\Filesystem;
 
-class Export extends Command
+final class Export extends Command
 {
-    protected function configure()
+    private const PS_CONFIGURATIONS_FILE = 'ps_configurations.json';
+
+    protected function configure(): void
     {
         $this->setName('fop:configuration:export')
             ->setDescription('Export configuration values')
-            ->addArgument('keys', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'configuration values to export')
-        ;
+            ->setHelp('Dump configuration to a json file.')
+            ->addOption('file', null, InputOption::VALUE_REQUIRED, 'file to dump to', self::PS_CONFIGURATIONS_FILE)
+            ->addArgument('keys', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'configuration values to export');
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
-        $io->title('Hello !');
+        $configuration_keys = (array) $input->getArgument('keys');
+
+        /** @var \PrestaShop\PrestaShop\Adapter\Configuration $configuration_service */
+        $configuration_service = $this->getContainer()->get('prestashop.adapter.legacy.configuration');
+
+        // @todo what to do if configuration key not found ?
+        // for the moment let's emit a simple warning. (throw an error is better ?)
+        // or event create an empty configuration value ?
+        $to_export = [];
+        foreach ($configuration_keys as $key) {
+            if (!$configuration_service->has($key)) {
+                $io->warning(sprintf("Configuration key not found '%s' : ignored.", $key));
+                continue;
+            }
+
+            $to_export[$key] = $configuration_service->get($key);
+        }
+
+        $json_export = json_encode($to_export, JSON_PRETTY_PRINT);
+        if (false === $json_export) { // useless ?
+            if ($io->isVeryVerbose()) {
+                $io->writeln('$to_export:');
+                dump($to_export);
+            }
+            throw new RuntimeException('Failed to json encode configuration');
+        }
+
+        // @todo : dump to stdout if on file provided or dump to a default file ?
+        // dump to a default file and add std output option
+        $fs = new Filesystem();
+        $fs->dumpFile($input->getOption('file'), $json_export);
+
+        // @todo list dumped configurations if verbose mode
+        $io->success("configuration(s) dumped to file '{$input->getOption('file')}'");
+
+        return 1;
     }
 }

--- a/src/Commands/Configuration/Export.php
+++ b/src/Commands/Configuration/Export.php
@@ -84,8 +84,6 @@ final class Export extends Command
             throw new RuntimeException('Failed to json encode configuration');
         }
 
-        // @todo : dump to stdout if on file provided or dump to a default file ?
-        // dump to a default file and add std output option
         $fs = new Filesystem();
         $fs->dumpFile($output_file, $json_export);
 

--- a/src/Commands/Configuration/Export.php
+++ b/src/Commands/Configuration/Export.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace FOP\Console\Commands\Configuration;
+
+use FOP\Console\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+class Export extends Command
+{
+    protected function configure()
+    {
+        $this->setName('fop:configuration:export')
+            ->setDescription('Export configuration values')
+            ->addArgument('keys', InputArgument::IS_ARRAY | InputArgument::REQUIRED, 'configuration values to export')
+        ;
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output)
+    {
+        $io = new SymfonyStyle($input, $output);
+        $io->title('Hello !');
+    }
+}

--- a/src/Commands/Configuration/Import.php
+++ b/src/Commands/Configuration/Import.php
@@ -20,7 +20,9 @@ final class Import extends Command
     {
         $this->setName('fop:configuration:import')
             ->setDescription('Import configuration values')
-            ->setHelp('Import configurations from a json file. ')
+            ->setHelp('Import configurations into ps_configuration table from a json file.'
+            . PHP_EOL . ' To generate an json file use the fop:configuration:export command'
+            )
             ->addOption('file', null, InputOption::VALUE_REQUIRED, 'file to import from', self::PS_CONFIGURATIONS_FILE);
     }
 

--- a/src/Commands/Configuration/Import.php
+++ b/src/Commands/Configuration/Import.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace FOP\Console\Commands\Configuration;
+
+use Exception;
+use FOP\Console\Command;
+use RuntimeException;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+final class Import extends Command
+{
+    private const PS_CONFIGURATIONS_FILE = 'ps_configurations.json';
+
+    protected function configure(): void
+    {
+        $this->setName('fop:configuration:import')
+            ->setDescription('Import configuration values')
+            ->setHelp('Import configurations from a json file. ')
+            ->addOption('file', null, InputOption::VALUE_REQUIRED, 'file to import from', self::PS_CONFIGURATIONS_FILE);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        try {
+            /** @var \PrestaShop\PrestaShop\Adapter\Configuration $configuration_service */
+            $configuration_service = $this->getContainer()->get('prestashop.adapter.legacy.configuration');
+
+            $source_file = $input->getOption('file');
+            if (!file_exists($source_file)) {
+                throw new RuntimeException("File $source_file not found.");
+            }
+            $configurations = json_decode(file_get_contents($source_file), true);
+            if (false === $configurations) {
+                throw new Exception('Failed to decode json !');
+            }
+
+            if ($output->isVerbose()) {
+                $io->writeln('Configuration imported : ');
+                $rows = [];
+                foreach ($configurations as $k => $v) {
+                    $rows[] = [$k, $v];
+                }
+                $io->table(['Configuration name', 'value'], $rows);
+            }
+            $configuration_service->add($configurations);
+
+            $io->success('Configurations imported');
+
+            return 0;
+        } catch (Exception $exception) {
+            $io->error('Command ' . $this->getName() . ' aborted : ' . $exception->getMessage());
+
+            return 1;
+        }
+    }
+}


### PR DESCRIPTION
Command to export and import configuration(s).

`fop:configuration:export` : export configurations to json. See command help for details.
`fop:configuration:import` : import configurations from a json file.