### PR TITLE
PrestaShop versions for phpstan - fix #103

### DIFF
--- a/.github/workflows/phpstan.yml
+++ b/.github/workflows/phpstan.yml
@@ -7,7 +7,7 @@ jobs:
 
     strategy:
       matrix:
-        presta-versions: [ '1.7.5.0', '1.7.6.9', '1.7.7.0' ]
+        presta-versions: [ '1.7.5.0', '1.7.5.2', '1.7.6.9', '1.7.7.3' ]
 
     steps:
       - name: Checkout


### PR DESCRIPTION
latest on 1.7.x branches from 1.7.5
+ 1.7.5.0 (first claimed compatible version).