### PR TITLE
Fix syntax error in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ You'll see commands provided by Symfony, Prestashop and installed modules.
 
 ```shell
 ./bin/console list
-
+```
 
 To list only fop commands :
 ```shell


### PR DESCRIPTION
Fix syntax error in command list
from
![image](https://user-images.githubusercontent.com/7163132/128705096-9984a18a-d834-4ec9-909e-7f6a4617eaf1.png)
to
![image](https://user-images.githubusercontent.com/7163132/128705150-270fd792-e342-494f-b8b4-0b484a67c6a9.png)
