### PR TITLE
chore: add missing theme's reset command

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ php bin/console pr:mo install fop_console
 * `fop:modules:non-essential`          Manage non essential modules
 * `fop:override:make`                  Generate a file to make an override.
 * `fop:shop-status`                    Display shops statuses
-* `fop:unhook-module`                  Detach module from hook
 * `fop:theme-reset`                    Reset current (or selected) theme
+* `fop:unhook-module`                  Detach module from hook
 
 ## Create your owns Commands
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ php bin/console pr:mo install fop_console
 * `fop:override:make`                  Generate a file to make an override.
 * `fop:shop-status`                    Display shops statuses
 * `fop:unhook-module`                  Detach module from hook
+* `fop:theme-reset`                    Reset current (or selected) theme
 
 ## Create your owns Commands
 


### PR DESCRIPTION
Hej !

I don't know why but the `fop:theme-reset` command has been deleted from the README by another commit.

<3