### PR TITLE
fix fop:about:version to comply with naming convention.

### DIFF
--- a/config/services.yml
+++ b/config/services.yml
@@ -121,8 +121,8 @@ services:
     class: FOP\Console\Commands\Theme\ThemeResetLayout
     tags: [ console.command ]
 
-  fop.console.version.command:
-    class: FOP\Console\Commands\About\Version
+  fop.console.about.version.command:
+    class: FOP\Console\Commands\About\AboutVersion
     tags: [ console.command ]
 
 imports:

--- a/src/Commands/About/AboutVersion.php
+++ b/src/Commands/About/AboutVersion.php
@@ -30,7 +30,7 @@ use RuntimeException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-final class Version extends Command
+final class AboutVersion extends Command
 {
     const GITHUB_RELEASES_YAML_URL = 'https://api.github.com/repos/friends-of-presta/fop_console/releases/latest';
 


### PR DESCRIPTION
will fix errors reported in [phpstan's new rule PR](https://github.com/friends-of-presta/fop_console/runs/4414291040?check_suite_focus=true).