### PR TITLE
`fop:debug-mode` is aliased to `fop:generate:htaccess`

### DIFF
--- a/src/Commands/Generate/GenerateHtaccess.php
+++ b/src/Commands/Generate/GenerateHtaccess.php
@@ -34,7 +34,6 @@ final class GenerateHtaccess extends Command
     {
         $this
             ->setName('fop:generate:htaccess')
-            ->setAliases(['fop:debug-mode'])
             ->setDescription('Generate the .htaccess file');
     }
 


### PR DESCRIPTION
![Capture d’écran de 2021-12-04 23-26-53](https://user-images.githubusercontent.com/2592502/144726437-fa671d4f-2486-4868-94e0-ea4940ff8537.png)

it should be aliased to `fop:environment:debug` only.