### PR TITLE
Fix code quality tools

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -30,4 +30,4 @@ jobs:
         run: |
           cd ${{ github.workspace }}
           ./vendor/bin/php-cs-fixer --version
-          ./vendor/bin/php-cs-fixer fix --dry-run --diff ./
+          ./vendor/bin/php-cs-fixer fix --config=".php_cs-fixer.dist.php" --dry-run --diff ./

--- a/.php_cs-fixer.dist.php
+++ b/.php_cs-fixer.dist.php
@@ -19,6 +19,7 @@ $fopPsConfig = new class extends PrestaShop\CodingStandards\CsFixer\Config {
 
 $fopPsConfig
     ->setUsingCache(true)
+    ->setCacheFile('.php_cs.cache')
     ->getFinder()
     ->in(__DIR__)
     ->exclude('vendor')

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
   "require-dev": {
     "prestashop/php-dev-tools": "4.*",
     "phpro/grumphp": "0.19.1",
-    "phpstan/phpstan": "^0.12.58",
+    "phpstan/phpstan": "1.*",
     "phpunit/phpunit": "^7.0"
   },
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f22f5d94a08bdec22bbb7bbaafe4682d",
+    "content-hash": "f4aee6fe9c4968be5e63b728b4362d22",
     "packages": [
         {
             "name": "laminas/laminas-code",

--- a/composer.lock
+++ b/composer.lock
@@ -3187,16 +3187,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "0.12.99",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "b4d40f1d759942f523be267a1bab6884f46ca3f7"
+                "reference": "cbe085f9fdead5b6d62e4c022ca52dc9427a10ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b4d40f1d759942f523be267a1bab6884f46ca3f7",
-                "reference": "b4d40f1d759942f523be267a1bab6884f46ca3f7",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/cbe085f9fdead5b6d62e4c022ca52dc9427a10ee",
+                "reference": "cbe085f9fdead5b6d62e4c022ca52dc9427a10ee",
                 "shasum": ""
             },
             "require": {
@@ -3212,7 +3212,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "0.12-dev"
+                    "dev-master": "1.2-dev"
                 }
             },
             "autoload": {
@@ -3227,7 +3227,7 @@
             "description": "PHPStan - PHP Static Analysis Tool",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan/issues",
-                "source": "https://github.com/phpstan/phpstan/tree/0.12.99"
+                "source": "https://github.com/phpstan/phpstan/tree/1.2.0"
             },
             "funding": [
                 {
@@ -3247,7 +3247,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-12T20:09:55+00:00"
+            "time": "2021-11-18T14:09:01+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -3,7 +3,7 @@ grumphp:
     phpcsfixer:
       config: .php_cs-fixer.dist.php
     phpstan:
-      level: 5 # Needed because Grum overwrite level at 0 by default in 0.19.1 version
+      level: 5 # Needed because Grumphp overwrites level at 0, by default in 0.19.1 version
       ignore_patterns: ['/(^\.|\/\.)/'] # Needed because PHPStan ignore dotfiles
       force_patterns: [] # Add dotfile to not ignore here
   parallel:

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -3,8 +3,9 @@ grumphp:
     phpcsfixer:
       config: .php_cs-fixer.dist.php
     phpstan:
-      level: 5 # Otherwise, Grum overwrite level at 0 by default in 0.19.1 version
-      ignore_patterns: ['/(^\.|\/\.)/'] # Ignore dot files because PHPStan does
+      level: 5 # Needed because Grum overwrite level at 0 by default in 0.19.1 version
+      ignore_patterns: ['/(^\.|\/\.)/'] # Needed because PHPStan ignore dotfiles
+      force_patterns: [] # Add dotfile to not ignore here
   parallel:
     enabled: false
   fixer:

--- a/grumphp.yml.dist
+++ b/grumphp.yml.dist
@@ -2,7 +2,9 @@ grumphp:
   tasks:
     phpcsfixer:
       config: .php_cs-fixer.dist.php
-    phpstan: ~
+    phpstan:
+      level: 5 # Otherwise, Grum overwrite level at 0 by default in 0.19.1 version
+      ignore_patterns: ['/(^\.|\/\.)/'] # Ignore dot files because PHPStan does
   parallel:
     enabled: false
   fixer:

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -14,6 +14,6 @@ parameters:
 
 includes:
   - %currentWorkingDirectory%/.devtools/.phpstan_bootstrap.neon
-  - %currentWorkingDirectory%/.devtools/phpstan_baseline.neon
+  - %currentWorkingDirectory%/phpstan_baseline.neon
   - %currentWorkingDirectory%/vendor/prestashop/php-dev-tools/phpstan/ps-module-extension.neon
   - %currentWorkingDirectory%/.devtools/fop_names_rules.neon

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -7,7 +7,7 @@ parameters:
     - .devtools/phpstan/stubs/
     - tests/Resources/
   reportUnmatchedIgnoredErrors: true
-  level: 5 # If changed, need to be changed in grumphp.yml.dist too
+  level: 5 # If changed, needs to be changed in grumphp.yml.dist too
   stubFiles:
     - .devtools/phpstan/stubs/Category.stub
     - .devtools/phpstan/stubs/Product.stub

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,7 +1,7 @@
 parameters:
   paths:
     - ./
-  excludes_analyse:
+  excludePaths:
     - vendor/
     - .devtools/phpstan/stubs/
     - tests/Resources/

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,16 +1,16 @@
 parameters:
   paths:
+    # If dotfile path added, need to be added in grumphp.yml.dist too
     - ./
   excludePaths:
     - vendor/
     - .devtools/phpstan/stubs/
     - tests/Resources/
   reportUnmatchedIgnoredErrors: true
-  level: 5
+  level: 5 # If changed, need to be changed in grumphp.yml.dist too
   stubFiles:
-      - .devtools/phpstan/stubs/Category.stub
-      - .devtools/phpstan/stubs/Product.stub
-
+    - .devtools/phpstan/stubs/Category.stub
+    - .devtools/phpstan/stubs/Product.stub
 
 includes:
   - %currentWorkingDirectory%/.devtools/.phpstan_bootstrap.neon

--- a/phpstan_baseline.neon
+++ b/phpstan_baseline.neon
@@ -3,22 +3,22 @@ parameters:
 		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Application\\:\\:getKernel\\(\\)\\.$#"
 			count: 1
-			path: ../src/Commands/Container/ContainerCheck.php
+			path: src/Commands/Container/ContainerCheck.php
 
 # That's fine, dump() can handle multiple values - This is not an error. https://github.com/symfony/var-dumper/blob/3.4/Resources/functions/dump.php
 		-
 			message: "#^Function dump invoked with 2 parameters, 1 required\\.$#"
 			count: 1
-			path: ../src/Commands/Configuration/ConfigurationExport.php
+			path: src/Commands/Configuration/ConfigurationExport.php
 
 # The rule can not determine if the command name is correct because it's constructed at runtime.
 		-
 			message: "#^Console command name can not be extracted\\. Therefore consistency with classname can't be checked\\.$#"
 			count: 1
-			path: ../src/Commands/Image/ImageGenerateAbstract.php
+			path: src/Commands/Image/ImageGenerateAbstract.php
 
 #	This error happens in a stub's test file. It must be ignored in the baseline otherwise the phpstan's unit test will fail.
 		-
 			message: "#^Call to an undefined method FOP\\\\Console\\\\Tests\\\\Resources\\\\Commands\\\\Domain\\\\DomainAction\\:\\:setName\\(\\)\\.$#"
 			count: 1
-			path: ../tests/Resources/Commands/Domain/DomainAction.php
+			path: tests/Resources/Commands/Domain/DomainAction.php

--- a/src/Commands/Container/ContainerCheck.php
+++ b/src/Commands/Container/ContainerCheck.php
@@ -22,7 +22,6 @@ namespace FOP\Console\Commands\Container;
 
 use Exception;
 use FOP\Console\Command;
-use PrestaShopBundle\Exception\NotImplementedException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -67,8 +66,6 @@ final class ContainerCheck extends Command
             ) {
                 try {
                     $this->getContainer()->get($serviceId);
-                } catch (NotImplementedException $notImplementedException) {
-                    $services[] = [$serviceId, '<comment>' . $this->formatException($notImplementedException) . '</comment>'];
                 } catch (Exception $exception) {
                     $services[] = [$serviceId, '<fg=red>' . $this->formatException($exception) . '</>'];
                 } catch (Throwable $error) {

--- a/src/Commands/Employee/EmployeeChangePassword.php
+++ b/src/Commands/Employee/EmployeeChangePassword.php
@@ -28,7 +28,6 @@ use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Console\Style\SymfonyStyle;
 use Tools;
 use Validate;
 

--- a/src/Commands/Module/ModuleRename.php
+++ b/src/Commands/Module/ModuleRename.php
@@ -330,7 +330,7 @@ final class ModuleRename extends Command
             ],
         ];
 
-        if (isset($this->newModuleInfos['author'])) {
+        if (!empty($this->newModuleInfos['author'])) {
             array_push(
                 $searchAndReplacePairs,
                 [
@@ -381,15 +381,11 @@ final class ModuleRename extends Command
         $replacePairs = [];
 
         foreach ($searchAndReplacePairs as $searchAndReplacePair) {
-            if (!isset($searchAndReplacePair['search'])
-                || empty($searchAndReplacePair['search'])) {
+            if (empty($searchAndReplacePair['search'])) {
                 continue;
             }
             $search = $searchAndReplacePair['search'];
-
-            $replace = isset($searchAndReplacePair['replace'])
-                ? $searchAndReplacePair['replace']
-                : '';
+            $replace = $searchAndReplacePair['replace'];
 
             $caseFormats = isset($searchAndReplacePair['caseFormats'])
                 ? $searchAndReplacePair['caseFormats']

--- a/tests/Unit/PhpStanNamesConsistencyRuleTest.php
+++ b/tests/Unit/PhpStanNamesConsistencyRuleTest.php
@@ -53,7 +53,7 @@ class PhpStanNamesConsistencyRuleTest extends RuleTestCase
         // this is because PhpStanNamesConsistencyRule::nodeIsInClassFopCommand() checks the FQDN and therefore it needs to be changed
         // with the namespace of the tested class (FOP\Console\Tests\Resources\Commands\Domain).
         /* @phpstan-ignore-next-line */
-        return new class ($mockedValidatorService) extends PhpStanNamesConsistencyRule {
+        return new class($mockedValidatorService) extends PhpStanNamesConsistencyRule {
             public const FOP_BASE_COMMAND_CLASS_NAME = 'FOP\Console\Tests\Resources\Commands\Command';
         };
     }

--- a/tests/Validator/FOPCommandFormatsValidator.php
+++ b/tests/Validator/FOPCommandFormatsValidator.php
@@ -31,7 +31,6 @@ use Exception; /**
  * - command name (symfony command name) is consistent with <Domain> and <Action>
  * - service name (symfony service declaration) is consistent with <Domain> and <Action>
  */
-
 class FOPCommandFormatsValidator
 {
     /**


### PR DESCRIPTION
Fixes #150 (and closes #203?).

Fixed issues:
• PHP-CS-Fixer workflow step wasn't using our custom configuration file.
• PHPStan was old... very old...
• GrumPHP was overwriting our level setting and checking dot files ([where PHPStan doesn't](https://github.com/phpstan/phpstan/discussions/6180#discussioncomment-1784130)).
