### PR TITLE
Fix "employee" option not found

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -34,11 +34,11 @@ abstract class Command extends ContainerAwareCommand
     /** @var \Symfony\Component\Console\Style\SymfonyStyle */
     protected $io;
     
-    protected function configure()
+    public function __construct(string $name = null)
     {
+        parent::__construct($name);
+
         $this->addOption('employee', '-em', InputOption::VALUE_REQUIRED, 'Specify employee context (id).', null);
-        
-        parent::configure();
     }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void

--- a/src/Command.php
+++ b/src/Command.php
@@ -33,12 +33,17 @@ abstract class Command extends ContainerAwareCommand
 {
     /** @var \Symfony\Component\Console\Style\SymfonyStyle */
     protected $io;
+    
+    protected function configure()
+    {
+        $this->addOption('employee', '-em', InputOption::VALUE_REQUIRED, 'Specify employee context (id).', null);
+        
+        parent::configure();
+    }
 
     protected function initialize(InputInterface $input, OutputInterface $output): void
     {
         $container = $this->getContainer();
-        $commandDefinition = $this->getDefinition();
-        $commandDefinition->addOption(new InputOption('employee', '-em', InputOption::VALUE_REQUIRED, 'Specify employee context (id).', null));
 
         $container->get('fop.console.console_loader')->loadConsoleContext($input);
 

--- a/src/Command.php
+++ b/src/Command.php
@@ -33,7 +33,7 @@ abstract class Command extends ContainerAwareCommand
 {
     /** @var \Symfony\Component\Console\Style\SymfonyStyle */
     protected $io;
-    
+
     public function __construct(string $name = null)
     {
         parent::__construct($name);


### PR DESCRIPTION
Fixes #255

I left the shortcut as defined, but I was not able to make it work.

-em=1
--em=1
-em1
-em 1
--em 1

Whatever I tried, I had "option not found" or "The file "/var/www/html/app/config/config_***.yml" does not exist because it falls under the `-e` option
