### PR TITLE
Update cache clearer service

### DIFF
--- a/src/Commands/Environment/EnvironmentSetupDev.php
+++ b/src/Commands/Environment/EnvironmentSetupDev.php
@@ -171,8 +171,8 @@ class EnvironmentSetupDev extends Command
 
         //Clear all cache
         $this->io->text('<info>Clear all cache</info>');
-        $cacheClearChain = $this->getContainer()->get('prestashop.adapter.cache_clearer');
-        $cacheClearChain->clearAllCaches();
+        $cacheClearChain = $this->getContainer()->get('prestashop.core.cache.clearer.cache_clearer_chain');
+        $cacheClearChain->clear();
 
         if (!$res) {
             //If error ROLLBACK sql update


### PR DESCRIPTION
Update deprecated prestashop.adapter.cache_clearer service

The `prestashop.adapter.cache_clearer` service has been removed in PrestaShop 8.0 and replaced by `prestashop.core.cache.clearer.cache_clearer_chain`. Updated the code to handle cache clearing using new service.